### PR TITLE
Add Netlify build for docs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,5 @@
 [build]
   base = "docs/"
   publish = "build/"
-  command = "npm install && npm build"
+  command = "npm run build"
 


### PR DESCRIPTION
Seems to be having some issues with some broken links:
```
Exhaustive list of all broken links found:

- On source page path = /docs/:
   -> linking to /docs/video-example
   -> linking to /docs/audio-example
   -> linking to /docs/text-example

- On source page path = /docs/wmmvideo-html:
   -> linking to videoComponent.js.html (resolved as: /docs/videoComponent.js.html)
   -> linking to videoComponent.js.html#line16 (resolved as: /docs/videoComponent.js.html)
   -> linking to videoComponent.js.html#line81 (resolved as: /docs/videoComponent.js.html)
```
